### PR TITLE
fix: 修复cdn引入时Vue.use报错

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ export {
   SmartWidget
 }
 
-if (typeof window !== 'undefined' && window.Vue) {
+if (typeof window !== 'undefined' && window.Vue && window.Vue.use) {
   window.Vue.use(install)
   if (install.installed) {
     install.installed = false


### PR DESCRIPTION
我有个Vue项目引入CDN时报window.Vue.use报错了，给你修好了，但是我本地打包lib失败，麻烦合并代码后你那边重新打包生成新的CDN